### PR TITLE
Add support for deep links + README fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
-# aidoku-rs
+# aidoku-as
 AssemblyScript wrapper for Aidoku sources.

--- a/src/Source.ts
+++ b/src/Source.ts
@@ -1,10 +1,5 @@
-import { Filter, Listing, MangaPageResult, Manga, Chapter, Page } from "./modules/aidoku";
+import { Filter, Listing, MangaPageResult, Manga, Chapter, Page, DeepLink } from "./modules/aidoku";
 import { Request } from "./modules/net";
-
-interface DeepLink {
-	manga: Manga | null;
-	chapter: Chapter | null;
-}
 
 export abstract class Source {
 	abstract getMangaList(filters: Filter[], page: number): MangaPageResult;

--- a/src/modules/aidoku/DeepLink.ts
+++ b/src/modules/aidoku/DeepLink.ts
@@ -1,0 +1,27 @@
+import { Manga } from "./Manga";
+import { Chapter } from "./Chapter";
+import { create_deeplink } from "./aidoku";
+
+/**
+ * Directly open mangas from aidoku://:sourceId/:mangaId URLs.
+ */
+export class DeepLink {
+    /**
+     * Creates a new DeepLink object.
+     * @param manga The manga of the deep link.
+     * @param chapter The chapter of the manga.
+     */
+    constructor(public manga: Manga | null, public chapter: Chapter | null) {
+        this.manga = manga;
+        this.chapter = chapter;   
+    }
+
+    /**
+     * The rid of the DeepLink object.
+     */
+    get value(): i32 {
+        const manga = this.manga?.value;
+        const chapter = this.chapter?.value;
+        return create_deeplink(manga ? manga : -1, chapter ? chapter : -1);
+    }
+}

--- a/src/modules/aidoku/DeepLink.ts
+++ b/src/modules/aidoku/DeepLink.ts
@@ -3,7 +3,7 @@ import { Chapter } from "./Chapter";
 import { create_deeplink } from "./aidoku";
 
 /**
- * Directly open mangas from aidoku://:sourceId/:mangaId URLs.
+ * Directly open manga from source website URLs.
  */
 export class DeepLink {
     /**
@@ -11,7 +11,7 @@ export class DeepLink {
      * @param manga The manga of the deep link.
      * @param chapter The chapter of the manga.
      */
-    constructor(public manga: Manga | null, public chapter: Chapter | null) {
+    constructor(public manga: Manga, public chapter: Chapter | null) {
         this.manga = manga;
         this.chapter = chapter;   
     }
@@ -20,8 +20,6 @@ export class DeepLink {
      * The rid of the DeepLink object.
      */
     get value(): i32 {
-        const manga = this.manga ? this.manga.value : null;
-        const chapter = this.chapter ? this.chapter.value : null;
-        return create_deeplink(manga ? manga : -1, chapter ? chapter : -1);
+        return create_deeplink(this.manga.value, this.chapter ? chapter.value : -1);
     }
 }

--- a/src/modules/aidoku/DeepLink.ts
+++ b/src/modules/aidoku/DeepLink.ts
@@ -20,8 +20,8 @@ export class DeepLink {
      * The rid of the DeepLink object.
      */
     get value(): i32 {
-        const manga = this.manga?.value;
-        const chapter = this.chapter?.value;
+        const manga = this.manga ? this.manga.value : null;
+        const chapter = this.chapter ? this.chapter.value : null;
         return create_deeplink(manga ? manga : -1, chapter ? chapter : -1);
     }
 }

--- a/src/modules/aidoku/aidoku.ts
+++ b/src/modules/aidoku/aidoku.ts
@@ -27,3 +27,8 @@ export declare function create_page(
 	base64: ArrayBuffer, base64_len: usize,
 	text: ArrayBuffer, text_len: usize
 ): i32;
+
+export declare function create_deeplink(
+	manga: i32,
+	chapter: i32,
+): i32;

--- a/src/modules/aidoku/index.ts
+++ b/src/modules/aidoku/index.ts
@@ -3,3 +3,4 @@ export * from "./Listing";
 export * from "./Manga";
 export * from "./Chapter";
 export * from "./Page";
+export * from "./DeepLink";


### PR DESCRIPTION
### Changes
DeepLinks can be created using the following syntax:
```ts
new DeepLink(manga, chapter);
```

Code is modeled after [aidoku-rs](https://github.com/Aidoku/aidoku-rs/blob/main/crates/lib/src/structs.rs#L275-L292).

----
Changes `aidoku-rs` to `aidoku-as` in README